### PR TITLE
feat: Overhaul DieselLinker macro and add comprehensive tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 proc-macro = true
 
 [dependencies]
-diesel = { version = "2.2.2", features = ["postgres", "postgres_backend"] }
+diesel = { version = "2.2.2", features = ["postgres", "postgres_backend", "sqlite"] }
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"

--- a/README.md
+++ b/README.md
@@ -2,20 +2,54 @@
 
 `DieselLinker` is a procedural macro that simplifies defining relationships between Diesel models. It allows you to define `one-to-many`, `many-to-one`, `one-to-one`, and `many-to-many` relationships with a simple attribute.
 
-## Prerequisites
+## Getting Started
+
+1.  Add `diesel_linker` to your `Cargo.toml`.
+2.  Define your Diesel models and schema as usual.
+3.  Add the `#[relation]` attribute to your model structs to define the relationships.
+
+### Prerequisites
 
 *   Rust and Cargo installed on your system.
 *   `diesel` and `diesel_linker` added to your `Cargo.toml`.
 
 ```toml
 [dependencies]
-diesel = { version = "2.2.2", features = ["postgres"] } # Or any other backend
+diesel = { version = "2.2.2", features = ["postgres", "sqlite"] } # Enable features for your database
 diesel_linker = "1.2.0" # Use the latest version
 ```
 
 ## Usage
 
-### Step 1: Define your models and schema
+### The `#[relation]` attribute
+
+The `#[relation]` attribute generates methods on your model structs to fetch related models.
+
+#### Common Attributes
+
+- `model`: **(Required)** The name of the related model as a string (e.g., `"Post"`).
+- `relation_type`: **(Required)** The type of relationship. Can be `"one_to_many"`, `"many_to_one"`, `"one_to_one"`, or `"many_to_many"`.
+- `backend`: **(Required)** The database backend you are using. Supported values are `"postgres"` and `"sqlite"`.
+
+#### Attributes for `many_to_one`
+
+- `fk`: **(Required)** The name of the foreign key column on the current model's table (e.g., `"user_id"`).
+
+#### Attributes for `many_to_many`
+
+- `join_table`: **(Required)** The name of the join table as a string (e.g., `"post_tags"`).
+- `fk_parent`: **(Required)** The foreign key in the join table that points to the current model (e.g., `"post_id"`).
+- `fk_child`: **(Required)** The foreign key in the join table that points to the related model (e.g., `"tag_id"`).
+- `primary_key`: The name of the primary key of the current model. Defaults to `"id"`.
+- `child_primary_key`: The name of the primary key of the related model. Defaults to the value of `primary_key` if specified, otherwise `"id"`.
+
+### Generated Methods
+
+The macro generates methods to fetch related objects. The method names are derived from the related model's name.
+- For `one-to-many` and `many-to-many`, it generates `get_<model_name_pluralized>()`. For example, a relation to `Post` will generate `get_posts()`.
+- For `one-to-one` and `many-to-one`, it generates `get_<model_name>()`. For example, a relation to `User` will generate `get_user()`.
+
+### Example: `one-to-many` and `many-to-one`
 
 First, define your Diesel models and schema as you would normally.
 
@@ -25,7 +59,6 @@ table! {
     users (id) {
         id -> Int4,
         name -> Varchar,
-        email -> Varchar,
     }
 }
 
@@ -34,69 +67,36 @@ table! {
         id -> Int4,
         user_id -> Int4,
         title -> Varchar,
-        body -> Text,
     }
 }
 
 joinable!(posts -> users (user_id));
-allow_tables_to_appear_in_same_query!(users, posts);
 ```
 
-### Step 2: Add the `#[relation]` attribute to your models
-
-Use the `#[relation]` attribute on your model structs to define the relationship.
-
-**Example: `one-to-many` and `many-to-one`**
+Then, add the `#[relation]` attribute to your models.
 
 ```rust
 // In your models.rs or similar
 use super::schema::{users, posts};
 use diesel_linker::relation;
 
-#[relation(model = "Post", relation_type = "one_to_many")]
+// Parent model
 #[derive(Queryable, Identifiable, Debug)]
 #[diesel(table_name = users)]
+#[relation(model = "Post", relation_type = "one_to_many", backend = "sqlite")]
 pub struct User {
     pub id: i32,
     pub name: String,
-    pub email: String,
 }
 
-#[relation(model = "User", fk= "user_id", relation_type = "many_to_one")]
+// Child model
 #[derive(Queryable, Identifiable, Debug, Associations)]
 #[diesel(belongs_to(User), table_name = posts)]
+#[relation(model = "User", fk = "user_id", relation_type = "many_to_one", backend = "sqlite")]
 pub struct Post {
     pub id: i32,
     pub user_id: i32,
     pub title: String,
-    pub body: String,
-}
-```
-
-### Step 3: Use the generated methods
-
-`DieselLinker` generates methods on your structs to fetch related models. The method names are generated based on the related model name (e.g., `get_<model_name>` or `get_<model_name>s`).
-
-```rust
-// For the one-to-many relationship on User
-impl User {
-    pub fn get_posts<C>(&self, conn: &C) -> diesel::QueryResult<Vec<Post>>
-    where C: diesel::Connection,
-          Post: diesel::BelongingTo<User>
-    {
-        use diesel::prelude::*;
-        Post::belonging_to(self).load::<Post>(conn)
-    }
-}
-
-// For the many-to-one relationship on Post
-impl Post {
-    pub fn get_user<C>(&self, conn: &C) -> diesel::QueryResult<User>
-    where C: diesel::Connection,
-    {
-        use diesel::prelude::*;
-        User::table.find(self.user_id).get_result::<User>(conn)
-    }
 }
 ```
 
@@ -105,20 +105,20 @@ Now you can use these methods in your application:
 ```rust
 fn main() {
     use diesel::prelude::*;
-    use diesel::pg::PgConnection;
+    use diesel::sqlite::SqliteConnection;
     // assuming you have your models and schema in a `db` module
     use your_project::db::models::{User, Post};
     use your_project::db::schema::users::dsl::*;
 
 
-    let mut connection = PgConnection::establish("postgres://user:password@localhost/mydb").unwrap();
+    let mut connection = SqliteConnection::establish(":memory:").unwrap();
+    // setup your database here...
 
     let user = users.find(1).first::<User>(&mut connection).expect("Error loading user");
     let user_posts = user.get_posts(&mut connection).expect("Error loading user posts");
 
     for post in user_posts {
         println!("Title: {}", post.title);
-        println!("Body: {}", post.body);
     }
 }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,58 +6,92 @@ mod utils;
 use proc_macro::TokenStream;
 use relation_macro::diesel_linker_impl;
 
-/// The `relation` attribute macro simplifies defining relationships between Diesel models.
+/// `diesel_linker` provides a procedural macro to simplify defining relationships between Diesel models.
 ///
-/// It generates methods to fetch related models based on the specified relationship type.
+/// This macro, `#[relation]`, generates methods on your model structs to fetch related models
+/// based on the specified relationship type. It supports `one-to-many`, `many-to-one`, `one-to-one`,
+/// and `many-to-many` relationships.
+///
+/// # Getting Started
+///
+/// 1.  Add `diesel_linker` to your `Cargo.toml`.
+/// 2.  Define your Diesel models and schema as usual.
+/// 3.  Add the `#[relation]` attribute to your model structs to define the relationships.
 ///
 /// # Attributes
 ///
-/// - `model`: The name of the related model.
-/// - `relation_type`: The type of relationship. Can be `one_to_many`, `many_to_one`, `one_to_one`, or `many_to_many`.
-/// - `fk`: The foreign key used for the relationship. Required for `many_to_one`.
-/// - `join_table`: The name of the join table. Required for `many_to_many`.
-/// - `fk_parent`: The foreign key for the parent in the join table. Required for `many_to_many`.
-/// - `fk_child`: The foreign key for the child in the join table. Required for `many_to_many`.
+/// The `#[relation]` attribute accepts the following arguments:
 ///
-/// # Example
+/// - `model`: **(Required)** The name of the related model as a string (e.g., `"Post"`).
+/// - `relation_type`: **(Required)** The type of relationship. Can be `"one_to_many"`, `"many_to_one"`, `"one_to_one"`, or `"many_to_many"`.
+/// - `backend`: **(Required)** The database backend you are using. Supported values are `"postgres"` and `"sqlite"`.
+///
+/// ## For `many_to_one`
+///
+/// - `fk`: **(Required)** The name of the foreign key column on the current model's table (e.g., `"user_id"`).
+///
+/// ## For `many_to_many`
+///
+/// - `join_table`: **(Required)** The name of the join table as a string (e.g., `"post_tags"`).
+/// - `fk_parent`: **(Required)** The foreign key in the join table that points to the current model (e.g., `"post_id"`).
+/// - `fk_child`: **(Required)** The foreign key in the join table that points to the related model (e.g., `"tag_id"`).
+/// - `primary_key`: The name of the primary key of the current model. Defaults to `"id"`.
+/// - `child_primary_key`: The name of the primary key of the related model. Defaults to the value of `primary_key` if specified, otherwise `"id"`.
+///
+/// # Generated Methods
+///
+/// The macro generates methods to fetch related objects. The method names are derived from the related model's name.
+/// - For `one-to-many` and `many-to-many`, it generates `get_<model_name_pluralized>()`. For example, a relation to `Post` will generate `get_posts()`.
+/// - For `one-to-one` and `many-to-one`, it generates `get_<model_name>()`. For example, a relation to `User` will generate `get_user()`.
+///
+/// # Example: `one-to-many` and `many-to-one`
 ///
 /// ```rust,ignore
-/// use diesel::prelude::*;
-/// use diesel_linker::relation;
+/// # // This example is ignored because it requires a database connection and full project setup.
+/// # use diesel::prelude::*;
+/// # use diesel_linker::relation;
+/// #
+/// # table! {
+/// #     users (id) {
+/// #         id -> Integer,
+/// #         name -> Text,
+/// #     }
+/// # }
+/// #
+/// # table! {
+/// #     posts (id) {
+/// #         id -> Integer,
+/// #         user_id -> Integer,
+/// #         title -> Text,
+/// #     }
+/// # }
+/// #
+/// # joinable!(posts -> users (user_id));
 ///
-/// table! {
-///     users (id) {
-///         id -> Integer,
-///         name -> Text,
-///     }
-/// }
-///
-/// table! {
-///     posts (id) {
-///         id -> Integer,
-///         user_id -> Integer,
-///         title -> Text,
-///     }
-/// }
-///
-/// joinable!(posts -> users (user_id));
-///
+/// // Parent model
 /// #[derive(Queryable, Identifiable, Debug)]
 /// #[diesel(table_name = users)]
-/// #[relation(model = "Post", relation_type = "one_to_many")]
+/// #[relation(model = "Post", relation_type = "one_to_many", backend = "sqlite")]
 /// pub struct User {
 ///     pub id: i32,
 ///     pub name: String,
 /// }
 ///
+/// // Child model
 /// #[derive(Queryable, Identifiable, Debug, Associations)]
 /// #[diesel(belongs_to(User), table_name = posts)]
-/// #[relation(model = "User", fk = "user_id", relation_type = "many_to_one")]
+/// #[relation(model = "User", fk = "user_id", relation_type = "many_to_one", backend = "sqlite")]
 /// pub struct Post {
 ///     pub id: i32,
 ///     pub user_id: i32,
 ///     pub title: String,
 /// }
+///
+/// // In your application code:
+/// // let user: User = ...;
+/// // let posts = user.get_posts(&mut connection)?;
+/// // let post: Post = ...;
+/// // let user_of_post = post.get_user(&mut connection)?;
 /// ```
 #[proc_macro_attribute]
 pub fn relation(attr: TokenStream, item: TokenStream) -> TokenStream {

--- a/src/relation_macro.rs
+++ b/src/relation_macro.rs
@@ -16,28 +16,41 @@ pub struct RelationAttributes {
     pub fk_parent: Option<String>,
     pub fk_child: Option<String>,
     pub method_name: Option<String>,
+    pub backend: String,
+    pub primary_key: Option<String>,
+    pub child_primary_key: Option<String>,
 }
 
 // Extracts the relation attributes from the attributes passed to the macro.
 fn extract_relation_attrs(parsed_attrs: &ParsedAttrs) -> Result<RelationAttributes, syn::Error> {
-    // Supposons que parsed_attrs contient déjà toutes les informations nécessaires
+    let relation_type = parsed_attrs
+        .relation_type
+        .clone()
+        .ok_or_else(|| syn::Error::new(Span::call_site(), "relation_type is missing"))?;
+
+    let fk = if relation_type == "many_to_one" {
+        parsed_attrs
+            .fk
+            .clone()
+            .ok_or_else(|| syn::Error::new(Span::call_site(), "fk is required for many_to_one relation"))?
+    } else {
+        parsed_attrs.fk.clone().unwrap_or_default()
+    };
+
     Ok(RelationAttributes {
         model: parsed_attrs
             .model
             .clone()
             .ok_or_else(|| syn::Error::new(Span::call_site(), "model is missing"))?,
-        fk: parsed_attrs
-            .fk
-            .clone()
-            .ok_or_else(|| syn::Error::new(Span::call_site(), "fk is missing"))?,
-        relation_type: parsed_attrs
-            .relation_type
-            .clone()
-            .ok_or_else(|| syn::Error::new(Span::call_site(), "relation_type is missing"))?,
+        fk,
+        relation_type,
         join_table: parsed_attrs.join_table.clone(),
         fk_parent: parsed_attrs.fk_parent.clone(),
         fk_child: parsed_attrs.fk_child.clone(),
         method_name: parsed_attrs.method_name.clone(),
+        backend: parsed_attrs.backend.clone().unwrap(),
+        primary_key: parsed_attrs.primary_key.clone(),
+        child_primary_key: parsed_attrs.child_primary_key.clone(),
     })
 }
 pub fn diesel_linker_impl(attrs: TokenStream, item: TokenStream) -> TokenStream {
@@ -64,6 +77,9 @@ pub fn diesel_linker_impl(attrs: TokenStream, item: TokenStream) -> TokenStream 
         relation_attrs.fk_parent,
         relation_attrs.fk_child,
         &relation_attrs.method_name,
+        &relation_attrs.backend,
+        &relation_attrs.primary_key,
+        &relation_attrs.child_primary_key,
     );
 
     TokenStream::from(quote! {
@@ -81,37 +97,30 @@ fn generate_relation_code(
     fk_parent: Option<String>,
     fk_child: Option<String>,
     method_name: &Option<String>,
+    backend: &str,
+    primary_key: &Option<String>,
+    child_primary_key: &Option<String>,
 ) -> proc_macro2::TokenStream {
     let model_ident = Ident::new(model, proc_macro2::Span::call_site());
+    let primary_key_ident = Ident::new(primary_key.as_deref().unwrap_or("id"), proc_macro2::Span::call_site());
+    let child_primary_key_ident = Ident::new(child_primary_key.as_deref().unwrap_or(primary_key.as_deref().unwrap_or("id")), proc_macro2::Span::call_site());
+
+    let conn_type = match backend {
+        "postgres" => quote! { diesel::pg::PgConnection },
+        "sqlite" => quote! { diesel::sqlite::SqliteConnection },
+        _ => return quote! { compile_error!("Unsupported backend. Supported backends are 'postgres' and 'sqlite'."); }.into(),
+    };
 
     match relation_type {
         "one_to_many" => {
             let get_method_name = method_name.as_ref().map(|s| Ident::new(s, proc_macro2::Span::call_site())).unwrap_or_else(|| Ident::new(&format!("get_{}", model.to_lowercase().to_plural()), proc_macro2::Span::call_site()));
-            let add_method_name = Ident::new(&format!("add_{}", model.to_lowercase().to_singular()), proc_macro2::Span::call_site());
-            let remove_method_name = Ident::new(&format!("remove_{}", model.to_lowercase().to_singular()), proc_macro2::Span::call_site());
-            let fk_ident = Ident::new(fk, proc_macro2::Span::call_site());
 
             quote! {
                 impl #struct_name {
-                    pub fn #get_method_name<C>(&self, conn: &mut C) -> diesel::QueryResult<Vec<#model_ident>>
-                    where C: diesel::Connection
+                    pub fn #get_method_name(&self, conn: &mut #conn_type) -> diesel::QueryResult<Vec<#model_ident>>
                     {
                         use diesel::prelude::*;
                         #model_ident::belonging_to(self).load::<#model_ident>(conn)
-                    }
-
-                    pub fn #add_method_name<C>(&self, conn: &mut C, child: &#model_ident) -> diesel::QueryResult<usize>
-                    where C: diesel::Connection
-                    {
-                        use diesel::prelude::*;
-                        diesel::update(child).set(crate::schema::#fk_ident.eq(self.id)).execute(conn)
-                    }
-
-                    pub fn #remove_method_name<C>(&self, conn: &mut C, child: &#model_ident) -> diesel::QueryResult<usize>
-                    where C: diesel::Connection
-                    {
-                        use diesel::prelude::*;
-                        diesel::update(child).set(crate::schema::#fk_ident.eq(None::<i32>)).execute(conn)
                     }
                 }
             }
@@ -119,13 +128,13 @@ fn generate_relation_code(
         "many_to_one" => {
             let method_name = method_name.as_ref().map(|s| Ident::new(s, proc_macro2::Span::call_site())).unwrap_or_else(|| Ident::new(&format!("get_{}", model.to_lowercase()), proc_macro2::Span::call_site()));
             let fk_ident = Ident::new(fk, proc_macro2::Span::call_site());
+            let table_name = Ident::new(&model.to_plural().to_snake_case(), proc_macro2::Span::call_site());
             quote! {
                 impl #struct_name {
-                    pub fn #method_name<C>(&self, conn: &mut C) -> diesel::QueryResult<#model_ident>
-                    where C: diesel::Connection,
+                    pub fn #method_name(&self, conn: &mut #conn_type) -> diesel::QueryResult<#model_ident>
                     {
                         use diesel::prelude::*;
-                        crate::schema::#model_ident::table.find(self.#fk_ident).get_result::<#model_ident>(conn)
+                        crate::schema::#table_name::table.find(self.#fk_ident).get_result::<#model_ident>(conn)
                     }
                 }
             }
@@ -134,8 +143,7 @@ fn generate_relation_code(
             let method_name = method_name.as_ref().map(|s| Ident::new(s, proc_macro2::Span::call_site())).unwrap_or_else(|| Ident::new(&format!("get_{}", model.to_lowercase()), proc_macro2::Span::call_site()));
             quote! {
                 impl #struct_name {
-                    pub fn #method_name<C>(&self, conn: &mut C) -> diesel::QueryResult<#model_ident>
-                    where C: diesel::Connection
+                    pub fn #method_name(&self, conn: &mut #conn_type) -> diesel::QueryResult<#model_ident>
                     {
                         use diesel::prelude::*;
                         #model_ident::belonging_to(self).first::<#model_ident>(conn)
@@ -151,39 +159,34 @@ fn generate_relation_code(
                 let get_method_name = method_name.as_ref().map(|s| Ident::new(s, proc_macro2::Span::call_site())).unwrap_or_else(|| Ident::new(&format!("get_{}", model.to_lowercase().to_plural()), proc_macro2::Span::call_site()));
                 let add_method_name = Ident::new(&format!("add_{}", model.to_lowercase().to_singular()), proc_macro2::Span::call_site());
                 let remove_method_name = Ident::new(&format!("remove_{}", model.to_lowercase().to_singular()), proc_macro2::Span::call_site());
+                let model_table_name = Ident::new(&model.to_plural().to_snake_case(), proc_macro2::Span::call_site());
 
                 quote! {
                     impl #struct_name {
-                        pub fn #get_method_name<C>(&self, conn: &mut C) -> diesel::QueryResult<Vec<#model_ident>>
-                        where
-                            C: diesel::Connection,
+                        pub fn #get_method_name(&self, conn: &mut #conn_type) -> diesel::QueryResult<Vec<#model_ident>>
                         {
                             use diesel::prelude::*;
                             let related_ids = crate::schema::#join_table_ident::table
-                                .filter(crate::schema::#parent_fk_ident.eq(self.id))
-                                .select(crate::schema::#child_fk_ident)
+                                .filter(crate::schema::#join_table_ident::#parent_fk_ident.eq(self.#primary_key_ident))
+                                .select(crate::schema::#join_table_ident::#child_fk_ident)
                                 .load::<i32>(conn)?;
-                            crate::schema::#model_ident::table.filter(crate::schema::id.eq_any(related_ids)).load::<#model_ident>(conn)
+                            crate::schema::#model_table_name::table.filter(crate::schema::#model_table_name::#child_primary_key_ident.eq_any(related_ids)).load::<#model_ident>(conn)
                         }
 
-                        pub fn #add_method_name<C>(&self, conn: &mut C, child: &#model_ident) -> diesel::QueryResult<usize>
-                        where
-                            C: diesel::Connection,
+                        pub fn #add_method_name(&self, conn: &mut #conn_type, child: &#model_ident) -> diesel::QueryResult<usize>
                         {
                             use diesel::prelude::*;
                             diesel::insert_into(crate::schema::#join_table_ident::table)
-                                .values((crate::schema::#parent_fk_ident.eq(self.id), crate::schema::#child_fk_ident.eq(child.id)))
+                                .values((crate::schema::#join_table_ident::#parent_fk_ident.eq(self.#primary_key_ident), crate::schema::#join_table_ident::#child_fk_ident.eq(child.#child_primary_key_ident)))
                                 .execute(conn)
                         }
 
-                        pub fn #remove_method_name<C>(&self, conn: &mut C, child: &#model_ident) -> diesel::QueryResult<usize>
-                        where
-                            C: diesel::Connection,
+                        pub fn #remove_method_name(&self, conn: &mut #conn_type, child: &#model_ident) -> diesel::QueryResult<usize>
                         {
                             use diesel::prelude::*;
                             diesel::delete(crate::schema::#join_table_ident::table
-                                .filter(crate::schema::#parent_fk_ident.eq(self.id))
-                                .filter(crate::schema::#child_fk_ident.eq(child.id)))
+                                .filter(crate::schema::#join_table_ident::#parent_fk_ident.eq(self.#primary_key_ident))
+                                .filter(crate::schema::#join_table_ident::#child_fk_ident.eq(child.#child_primary_key_ident)))
                                 .execute(conn)
                         }
                     }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,29 +3,76 @@ pub mod schema;
 use diesel::prelude::*;
 use diesel::sqlite::SqliteConnection;
 use diesel_linker::relation;
-use crate::schema::{users, posts};
+use crate::schema::{users, posts, user_profiles, tags, post_tags};
 
 #[derive(Queryable, Identifiable, Insertable, Debug, PartialEq)]
 #[diesel(table_name = users)]
-#[relation(model = "Post", fk = "user_id", relation_type = "one_to_many")]
+#[relation(model = "Post", relation_type = "one_to_many", backend = "sqlite")]
+#[relation(model = "UserProfile", relation_type = "one_to_one", backend = "sqlite")]
 pub struct User {
     pub id: i32,
     pub name: String,
 }
 
 #[derive(Queryable, Identifiable, Insertable, Associations, Debug, PartialEq)]
+#[diesel(belongs_to(User), table_name = user_profiles)]
+pub struct UserProfile {
+    pub id: i32,
+    pub user_id: i32,
+    pub bio: String,
+}
+
+#[derive(Queryable, Identifiable, Insertable, Associations, Debug, PartialEq)]
 #[diesel(belongs_to(User), table_name = posts)]
-#[relation(model = "User", fk = "user_id", relation_type = "many_to_one")]
+#[relation(model = "User", fk = "user_id", relation_type = "many_to_one", backend = "sqlite")]
+#[relation(
+    model = "Tag",
+    relation_type = "many_to_many",
+    join_table = "post_tags",
+    fk_parent = "post_id",
+    fk_child = "tag_id",
+    backend = "sqlite",
+    child_primary_key = "tag_id"
+)]
 pub struct Post {
     pub id: i32,
-    pub user_id: Option<i32>,
+    pub user_id: i32,
     pub title: String,
+}
+
+#[derive(Queryable, Identifiable, Insertable, Debug, PartialEq)]
+#[diesel(table_name = tags)]
+#[diesel(primary_key(tag_id))]
+#[relation(
+    model = "Post",
+    relation_type = "many_to_many",
+    join_table = "post_tags",
+    fk_parent = "tag_id",
+    fk_child = "post_id",
+    backend = "sqlite",
+    primary_key = "tag_id",
+    child_primary_key = "id"
+)]
+pub struct Tag {
+    pub tag_id: i32,
+    pub name: String,
+}
+
+#[derive(Queryable, Identifiable, Insertable, Associations, Debug, PartialEq)]
+#[diesel(belongs_to(Post), belongs_to(Tag), table_name = post_tags)]
+pub struct PostTag {
+    pub id: i32,
+    pub post_id: i32,
+    pub tag_id: i32,
 }
 
 fn setup_db() -> SqliteConnection {
     let mut conn = SqliteConnection::establish(":memory:").unwrap();
     diesel::sql_query("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)").execute(&mut conn).unwrap();
-    diesel::sql_query("CREATE TABLE posts (id INTEGER PRIMARY KEY, user_id INTEGER, title TEXT NOT NULL)").execute(&mut conn).unwrap();
+    diesel::sql_query("CREATE TABLE posts (id INTEGER PRIMARY KEY, user_id INTEGER NOT NULL, title TEXT NOT NULL)").execute(&mut conn).unwrap();
+    diesel::sql_query("CREATE TABLE user_profiles (id INTEGER PRIMARY KEY, user_id INTEGER NOT NULL, bio TEXT NOT NULL)").execute(&mut conn).unwrap();
+    diesel::sql_query("CREATE TABLE tags (tag_id INTEGER PRIMARY KEY, name TEXT NOT NULL)").execute(&mut conn).unwrap();
+    diesel::sql_query("CREATE TABLE post_tags (id INTEGER PRIMARY KEY, post_id INTEGER NOT NULL, tag_id INTEGER NOT NULL)").execute(&mut conn).unwrap();
     conn
 }
 
@@ -36,12 +83,62 @@ fn test_one_to_many_get() {
     let new_user = User { id: 1, name: "Alice".to_string() };
     diesel::insert_into(users::table).values(&new_user).execute(&mut conn).unwrap();
 
-    let new_post = Post { id: 1, user_id: Some(1), title: "First post".to_string() };
+    let new_post = Post { id: 1, user_id: 1, title: "First post".to_string() };
     diesel::insert_into(posts::table).values(&new_post).execute(&mut conn).unwrap();
 
     let user = users::table.find(1).first::<User>(&mut conn).unwrap();
     let posts = user.get_posts(&mut conn).unwrap();
 
+    assert_eq!(posts.len(), 1);
+    assert_eq!(posts[0].title, "First post");
+
+    let post = posts::table.find(1).first::<Post>(&mut conn).unwrap();
+    let user_of_post = post.get_user(&mut conn).unwrap();
+    assert_eq!(user_of_post.id, 1);
+    assert_eq!(user_of_post.name, "Alice");
+}
+
+#[test]
+fn test_one_to_one_get() {
+    use crate::schema::{users, user_profiles};
+    let mut conn = setup_db();
+
+    let new_user = User { id: 1, name: "Alice".to_string() };
+    diesel::insert_into(users::table).values(&new_user).execute(&mut conn).unwrap();
+
+    let new_profile = UserProfile { id: 1, user_id: 1, bio: "Alice's bio".to_string() };
+    diesel::insert_into(user_profiles::table).values(&new_profile).execute(&mut conn).unwrap();
+
+    let user = users::table.find(1).first::<User>(&mut conn).unwrap();
+    let profile = user.get_userprofile(&mut conn).unwrap();
+
+    assert_eq!(profile.bio, "Alice's bio");
+}
+
+#[test]
+fn test_many_to_many_get() {
+    use crate::schema::{users, posts, tags, post_tags};
+    let mut conn = setup_db();
+
+    let new_user = User { id: 1, name: "Alice".to_string() };
+    diesel::insert_into(users::table).values(&new_user).execute(&mut conn).unwrap();
+
+    let new_post = Post { id: 1, user_id: 1, title: "First post".to_string() };
+    diesel::insert_into(posts::table).values(&new_post).execute(&mut conn).unwrap();
+
+    let new_tag = Tag { tag_id: 1, name: "rust".to_string() };
+    diesel::insert_into(tags::table).values(&new_tag).execute(&mut conn).unwrap();
+
+    let new_post_tag = PostTag { id: 1, post_id: 1, tag_id: 1 };
+    diesel::insert_into(post_tags::table).values(&new_post_tag).execute(&mut conn).unwrap();
+
+    let post = posts::table.find(1).first::<Post>(&mut conn).unwrap();
+    let tags = post.get_tags(&mut conn).unwrap();
+    assert_eq!(tags.len(), 1);
+    assert_eq!(tags[0].name, "rust");
+
+    let tag = tags::table.find(1).first::<Tag>(&mut conn).unwrap();
+    let posts = tag.get_posts(&mut conn).unwrap();
     assert_eq!(posts.len(), 1);
     assert_eq!(posts[0].title, "First post");
 }

--- a/tests/postgres_test.rs
+++ b/tests/postgres_test.rs
@@ -1,0 +1,149 @@
+pub mod schema;
+
+use diesel::prelude::*;
+use diesel::pg::PgConnection;
+use diesel_linker::relation;
+use crate::schema::{users, posts, user_profiles, tags, post_tags};
+use std::env;
+
+#[derive(Queryable, Identifiable, Insertable, Debug, PartialEq)]
+#[diesel(table_name = users)]
+#[relation(model = "Post", relation_type = "one_to_many", backend = "postgres")]
+#[relation(model = "UserProfile", relation_type = "one_to_one", backend = "postgres")]
+pub struct User {
+    pub id: i32,
+    pub name: String,
+}
+
+#[derive(Queryable, Identifiable, Insertable, Associations, Debug, PartialEq)]
+#[diesel(belongs_to(User), table_name = user_profiles)]
+pub struct UserProfile {
+    pub id: i32,
+    pub user_id: i32,
+    pub bio: String,
+}
+
+#[derive(Queryable, Identifiable, Insertable, Associations, Debug, PartialEq)]
+#[diesel(belongs_to(User), table_name = posts)]
+#[relation(model = "User", fk = "user_id", relation_type = "many_to_one", backend = "postgres")]
+#[relation(
+    model = "Tag",
+    relation_type = "many_to_many",
+    join_table = "post_tags",
+    fk_parent = "post_id",
+    fk_child = "tag_id",
+    backend = "postgres",
+    child_primary_key = "tag_id"
+)]
+pub struct Post {
+    pub id: i32,
+    pub user_id: i32,
+    pub title: String,
+}
+
+#[derive(Queryable, Identifiable, Insertable, Debug, PartialEq)]
+#[diesel(table_name = tags)]
+#[diesel(primary_key(tag_id))]
+#[relation(
+    model = "Post",
+    relation_type = "many_to_many",
+    join_table = "post_tags",
+    fk_parent = "tag_id",
+    fk_child = "post_id",
+    backend = "postgres",
+    primary_key = "tag_id",
+    child_primary_key = "id"
+)]
+pub struct Tag {
+    pub tag_id: i32,
+    pub name: String,
+}
+
+#[derive(Queryable, Identifiable, Insertable, Associations, Debug, PartialEq)]
+#[diesel(belongs_to(Post), belongs_to(Tag), table_name = post_tags)]
+pub struct PostTag {
+    pub id: i32,
+    pub post_id: i32,
+    pub tag_id: i32,
+}
+
+fn setup_db() -> PgConnection {
+    let database_url = env::var("DATABASE_URL").unwrap_or_else(|_| "postgres://test:test@localhost:5432/test".to_string());
+    let mut conn = PgConnection::establish(&database_url).unwrap();
+    diesel::sql_query("DROP TABLE IF EXISTS post_tags, tags, user_profiles, posts, users;").execute(&mut conn).unwrap();
+    diesel::sql_query("CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL)").execute(&mut conn).unwrap();
+    diesel::sql_query("CREATE TABLE posts (id SERIAL PRIMARY KEY, user_id INTEGER NOT NULL, title TEXT NOT NULL)").execute(&mut conn).unwrap();
+    diesel::sql_query("CREATE TABLE user_profiles (id SERIAL PRIMARY KEY, user_id INTEGER NOT NULL, bio TEXT NOT NULL)").execute(&mut conn).unwrap();
+    diesel::sql_query("CREATE TABLE tags (tag_id SERIAL PRIMARY KEY, name TEXT NOT NULL)").execute(&mut conn).unwrap();
+    diesel::sql_query("CREATE TABLE post_tags (id SERIAL PRIMARY KEY, post_id INTEGER NOT NULL, tag_id INTEGER NOT NULL)").execute(&mut conn).unwrap();
+    conn
+}
+
+#[test]
+#[ignore]
+fn test_one_to_many_get_pg() {
+    let mut conn = setup_db();
+
+    let new_user = diesel::insert_into(users::table).values(users::name.eq("Alice")).get_result::<User>(&mut conn).unwrap();
+    let new_post = diesel::insert_into(posts::table)
+        .values((posts::user_id.eq(new_user.id), posts::title.eq("First post")))
+        .get_result::<Post>(&mut conn)
+        .unwrap();
+
+    let user = users::table.find(new_user.id).first::<User>(&mut conn).unwrap();
+    let posts = user.get_posts(&mut conn).unwrap();
+
+    assert_eq!(posts.len(), 1);
+    assert_eq!(posts[0].title, "First post");
+
+    let post = posts::table.find(new_post.id).first::<Post>(&mut conn).unwrap();
+    let user_of_post = post.get_user(&mut conn).unwrap();
+    assert_eq!(user_of_post.id, new_user.id);
+    assert_eq!(user_of_post.name, "Alice");
+}
+
+#[test]
+#[ignore]
+fn test_one_to_one_get_pg() {
+    use crate::schema::{users, user_profiles};
+    let mut conn = setup_db();
+
+    let new_user = diesel::insert_into(users::table).values(users::name.eq("Alice")).get_result::<User>(&mut conn).unwrap();
+    diesel::insert_into(user_profiles::table)
+        .values((user_profiles::user_id.eq(new_user.id), user_profiles::bio.eq("Alice's bio")))
+        .execute(&mut conn)
+        .unwrap();
+
+    let user = users::table.find(new_user.id).first::<User>(&mut conn).unwrap();
+    let profile = user.get_userprofile(&mut conn).unwrap();
+
+    assert_eq!(profile.bio, "Alice's bio");
+}
+
+#[test]
+#[ignore]
+fn test_many_to_many_get_pg() {
+    use crate::schema::{users, posts, tags, post_tags};
+    let mut conn = setup_db();
+
+    let new_user = diesel::insert_into(users::table).values(users::name.eq("Alice")).get_result::<User>(&mut conn).unwrap();
+    let new_post = diesel::insert_into(posts::table)
+        .values((posts::user_id.eq(new_user.id), posts::title.eq("First post")))
+        .get_result::<Post>(&mut conn)
+        .unwrap();
+    let new_tag = diesel::insert_into(tags::table).values(tags::name.eq("rust")).get_result::<Tag>(&mut conn).unwrap();
+    diesel::insert_into(post_tags::table)
+        .values((post_tags::post_id.eq(new_post.id), post_tags::tag_id.eq(new_tag.tag_id)))
+        .execute(&mut conn)
+        .unwrap();
+
+    let post = posts::table.find(new_post.id).first::<Post>(&mut conn).unwrap();
+    let tags = post.get_tags(&mut conn).unwrap();
+    assert_eq!(tags.len(), 1);
+    assert_eq!(tags[0].name, "rust");
+
+    let tag = tags::table.find(new_tag.tag_id).first::<Tag>(&mut conn).unwrap();
+    let posts = tag.get_posts(&mut conn).unwrap();
+    assert_eq!(posts.len(), 1);
+    assert_eq!(posts[0].title, "First post");
+}

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -10,9 +10,39 @@ table! {
 table! {
     posts (id) {
         id -> Integer,
-        user_id -> Nullable<Integer>,
+        user_id -> Integer,
         title -> Text,
     }
 }
 
 joinable!(posts -> users (user_id));
+
+table! {
+    user_profiles (id) {
+        id -> Integer,
+        user_id -> Integer,
+        bio -> Text,
+    }
+}
+
+joinable!(user_profiles -> users (user_id));
+
+table! {
+    tags (tag_id) {
+        tag_id -> Integer,
+        name -> Text,
+    }
+}
+
+table! {
+    post_tags (id) {
+        id -> Integer,
+        post_id -> Integer,
+        tag_id -> Integer,
+    }
+}
+
+joinable!(post_tags -> posts (post_id));
+joinable!(post_tags -> tags (tag_id));
+use diesel::allow_tables_to_appear_in_same_query;
+allow_tables_to_appear_in_same_query!(posts, post_tags, tags);


### PR DESCRIPTION
This commit introduces a series of improvements to the `diesel_linker` procedural macro.

Key changes include:
- **Backend-Specific Code Generation**: The macro now requires a `backend` attribute (`postgres` or `sqlite`) to generate backend-specific code, resolving complex trait bound issues with Diesel.
- **Custom Primary Key Support**: Added `primary_key` and `child_primary_key` attributes to support models with primary keys other than `id`, especially for `many-to-many` relationships.
- **API Simplification**: Removed the `add_` and `remove_` methods from `one_to_many` relations, as they were not robust and encouraged an unconventional pattern.
- **Expanded Test Suite**: Added a comprehensive integration test suite covering `one-to-one`, `many-to-one`, and `many-to-many` relationships for the SQLite backend. Also added a (currently ignored) test suite for PostgreSQL.
- **Improved Documentation**: Rewrote the crate-level documentation and the `README.md` in English to be clearer, more detailed, and to reflect all the new changes.