### PR TITLE
fix(ci): Use 127.0.0.1 instead of localhost for db services

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,8 +8,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  DATABASE_URL: postgres://postgres:postgres@localhost/diesel_linker_test
-  MYSQL_URL: mysql://root:password@localhost:3306/diesel_linker_test
+  DATABASE_URL: postgres://postgres:postgres@127.0.0.1/diesel_linker_test
+  MYSQL_URL: mysql://root:password@127.0.0.1:3306/diesel_linker_test
 
 jobs:
   test:


### PR DESCRIPTION
This commit fixes the database connection issue in the CI pipeline.

The MySQL client library attempts to use a Unix socket when connecting to `localhost`, which is not available from the test container to the service container.

By changing the host from `localhost` to `127.0.0.1`, we force the client to use a TCP connection, which resolves the issue. The PostgreSQL connection string has also been updated for consistency.