### PR TITLE
chore: Bump version to 1.3.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,5 +54,4 @@ jobs:
       run: sleep 15 # Wait for mysql to be ready. A better solution would be to use a script that polls the db.
 
     - name: Run tests
-
       run: cargo test -- --test-threads=1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel_linker"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 description = "A procedural macro to link Diesel models"
 authors = ["Paterne G. G. paterne81@hotmail.fr"]


### PR DESCRIPTION
This commit bumps the crate version to 1.3.0 in preparation for a new release.

This new version includes major new features:
- Asynchronous support via `diesel-async`.
- Custom error types for generated methods.
- A CI pipeline to test against PostgreSQL and MySQL.
- Updated documentation and contribution guidelines.